### PR TITLE
updated the viewer to allow for holes to be shown

### DIFF
--- a/src/View/mainpage/DicomView.py
+++ b/src/View/mainpage/DicomView.py
@@ -174,8 +174,14 @@ class DicomView(QtWidgets.QWidget):
         color.setAlpha(roi_opacity)
         pen_color = QtGui.QColor(color.red(), color.green(), color.blue())
         pen = self.get_qpen(pen_color, roi_line, line_width)
-        for i in range(len(polygons)):
-            self.scene.addPolygon(polygons[i], pen, QtGui.QBrush(color))
+        path = QtGui.QPainterPath()
+        path.setFillRule(QtCore.Qt.OddEvenFill)
+        for i,poly in enumerate(polygons):
+            path.addPolygon(poly)
+        new_polygon = QtWidgets.QGraphicsPathItem(path)
+        new_polygon.setBrush(QtGui.QBrush(color))
+        new_polygon.setPen(pen)
+        self.scene.addItem(new_polygon)
 
     def get_qpen(self, color, style=1, widthF=1.):
         """


### PR DESCRIPTION
Changed the way the polygons are added to the display scene to allow for the viewing of "holes" in drawing. 
This update only effects the viewing, drawing has not yet been updated.

## Summary by Sourcery

Enable hole rendering in ROI polygon views by switching to a QPainterPath-based drawing approach with the odd-even fill rule.

New Features:
- Allow ROI polygons with holes to be displayed in the viewer

Enhancements:
- Refactor draw_roi_polygons to use QPainterPath and QGraphicsPathItem with an odd-even fill rule