### PR TITLE
Critical Bug Fix fixed image fusion on mac

### DIFF
--- a/src/View/ImageFusion/ImageFusionWindow.py
+++ b/src/View/ImageFusion/ImageFusionWindow.py
@@ -189,6 +189,10 @@ class UIImageFusionWindow(object):
 
         self.open_patient_window_instance_vertical_box.addWidget(fusion_mode_container)
 
+        #  Re-validate selection when fusion mode changes ---
+        self.manual_radio.toggled.connect(self._on_fusion_mode_changed)
+        self.auto_radio.toggled.connect(self._on_fusion_mode_changed)
+
         # Create a horizontal box to hold the Cancel and Open button
         self.open_patient_window_patient_open_actions_horizontal_box = \
             QHBoxLayout()
@@ -703,32 +707,42 @@ class UIImageFusionWindow(object):
 
     def on_loaded(self, results):
         """
-        Executes when the progress bar finishes loaded the selected files.
-        Emits a wrapper object that provides update_progress for compatibility with the main window.
-        """
-        # Handle both manual and auto fusion result types
-        if isinstance(results, tuple) and results[0] is True:
-            # Manual fusion: results is (True, images_dict)
-            images = results[1]
-            if isinstance(images, dict) and "vtk_engine" in images:
-                # Manual fusion: add dummy keys for main window compatibility
-                images["fixed_image"] = None
-                images["moving_image"] = None
-                # --- Set manual_fusion in PatientDictContainer ---
-                loader = ManualFusionLoader([], None)  # dummy loader for static call
-                loader.on_manual_fusion_loaded((True, images))
+                       Executes when the progress bar finishes loaded the selected files.
+                       Emits a wrapper object that provides update_progress for compatibility with the main window.
+                       """
 
-            wrapper = FusionResultWrapper(images, self.progress_window)
-            self.image_fusion_info_initialized.emit(wrapper)
+        # Handle both manual and auto fusion result types
+        if isinstance(results, tuple):
+            if results[0] is True:
+                # Manual fusion: results is (True, images_dict)
+                images = results[1]
+                if isinstance(images, dict) and "vtk_engine" in images:
+                    # Manual fusion: add dummy keys for main window compatibility
+                    images["fixed_image"] = None
+                    images["moving_image"] = None
+                    # --- Set manual_fusion in PatientDictContainer ---
+                    loader = ManualFusionLoader([], None)  # dummy loader for static call
+                    loader.on_manual_fusion_loaded((True, images))
+
+                wrapper = FusionResultWrapper(images, self.progress_window)
+                self.image_fusion_info_initialized.emit(wrapper)
+            else:
+                # Tuple but not success: treat as error
+                error_msg = results[1] if len(results) > 1 else "Unknown error"
+                QMessageBox.warning(self.progress_window, "Fusion Error", f"Fusion failed: {error_msg}")
         elif hasattr(results, "update_progress"):
-            # Autofusion: results is a ProgressWindow or similar
             wrapper = FusionResultWrapper(results, self.progress_window)
             self.image_fusion_info_initialized.emit(wrapper)
+        elif results is True:
+            images = {}
+            wrapper = FusionResultWrapper(images, self.progress_window)
+            self.image_fusion_info_initialized.emit(wrapper)
+        elif results is False:
+            QMessageBox.warning(self.progress_window, "Fusion Error", "Auto fusion failed to load images.")
         else:
-            # Unexpected result type
-            QMessageBox.warning(self, "Fusion Error", "Unexpected result type returned from fusion loader.")
-
-
+            QMessageBox.warning(self.progress_window,
+                                "Fusion Error",
+                                f"Unexpected result type returned from fusion loader: {type(results)}")
 
 
     def on_loading_error(self, exception):
@@ -747,6 +761,26 @@ class UIImageFusionWindow(object):
                               "Selected files cannot be opened as they contain"
                               " unsupported DICOM classes.")
             self.progress_window.close()
+
+    def _on_fusion_mode_changed(self):
+        """
+        Called when the fusion mode radio button is toggled.
+        Re-checks the selected items and disables confirm if requirements are not met.
+        """
+        # Find the currently selected patient (if any)
+        root = self.open_patient_window_patients_tree.invisibleRootItem()
+        checked_nodes = self.get_checked_nodes(root)
+        # If any node is checked, find its top-level parent (the patient)
+        selected_patient = None
+        if checked_nodes:
+            selected_patient = checked_nodes[0]
+            while selected_patient.parent() is not None:
+                selected_patient = selected_patient.parent()
+        # Re-run the selection check
+        if selected_patient is not None:
+            self.check_selected_items(selected_patient)
+        else:
+            self.open_patient_window_confirm_button.setDisabled(True)
 
 
 # This is to allow for dropping a directory into the input text.

--- a/src/View/ImageFusion/ManualFusionLoader.py
+++ b/src/View/ImageFusion/ManualFusionLoader.py
@@ -78,11 +78,9 @@ class ManualFusionLoader(QtCore.QObject):
                 return
             self._load_with_vtk(main_thread_progress_callback)
         except Exception as e:
-            import traceback
-            stack = traceback.format_exc()
             main_thread_progress_callback(("Error loading images", e))
-            logging.exception("Error loading images: %s\n%s", e, stack)
-            self.signal_error.emit((False, f"{e}\n{stack}"))
+            logging.exception("Error loading images: %s\n%s", e)
+            self.signal_error.emit((False, f"{e}"))
 
     def _load_with_vtk(self, progress_callback):
         """

--- a/src/View/ImageFusion/ManualFusionLoader.py
+++ b/src/View/ImageFusion/ManualFusionLoader.py
@@ -66,7 +66,16 @@ class ManualFusionLoader(QtCore.QObject):
         # Wrap the progress_callback so it always runs in the main thread
         def main_thread_progress_callback(*args, **kwargs):
             if progress_callback is not None:
-                progress_callback(*args, **kwargs)
+                # If progress_callback happens to be a Qt Signal, use QMetaObject.invokeMethod to ensure main thread execution
+                if hasattr(progress_callback, "emit"):
+                    QtCore.QMetaObject.invokeMethod(
+                        progress_callback,
+                        "emit",
+                        QtCore.Qt.QueuedConnection,
+                        QtCore.Q_ARG(object, args if len(args) > 1 else args[0])
+                    )
+                else:
+                    progress_callback(*args, **kwargs)
 
         self._interrupt_flag = interrupt_flag
         try:

--- a/src/View/ImageFusion/MovingImageLoader.py
+++ b/src/View/ImageFusion/MovingImageLoader.py
@@ -28,7 +28,8 @@ class MovingImageLoader(ImageLoader):
         super(MovingImageLoader, self).__init__(*args, **kwargs)
 
     def get_common_path_and_datasets(self):
-        path = os.path.dirname(os.path.commonprefix(self.selected_files))
+        # Use commonpath for correct path handling (not commonprefix)
+        path = os.path.commonpath(self.selected_files)
         read_data_dict, file_names_dict = ImageLoading.get_datasets(
             self.selected_files
         )
@@ -113,10 +114,10 @@ class MovingImageLoader(ImageLoader):
     def load(self, interrupt_flag, progress_callback, manual=False):
         # initial callback
         if manual:
-            progress_callback.emit(("Generating Moving Model", 20))
-        else:
+            progress_callback(("Generating Moving Model", 20))
+        elif hasattr(progress_callback, "emit"):
             progress_callback.emit(("Creating datasets...", 0))
-        
+
         # load datasets and common path
         try:
             path, read_data_dict, file_names_dict = self.get_common_path_and_datasets()
@@ -127,19 +128,19 @@ class MovingImageLoader(ImageLoader):
 
         if interrupt_flag.is_set():
             return False
-        
+
         # check for RTSS and RTDOSE, ask to calculate DVH if both present
         if 'rtss' in file_names_dict and 'rtdose' in file_names_dict:
             self.parent_window.signal_advise_calc_dvh.connect(self.update_calc_dvh)
             self.signal_request_calc_dvh.emit()
             while not self.advised_calc_dvh:
                 pass
-    
+
         # handle RTSS (roi + contour data)
         if 'rtss' in file_names_dict:
             if manual:
-                progress_callback.emit(("Getting ROI + Contour data...", 25))
-            else:
+                progress_callback(("Getting ROI + Contour data...", 25))
+            elif hasattr(progress_callback, "emit"):
                 progress_callback.emit(("Getting ROI + Contour data...", 10))
 
             dataset_rtss, rois, dict_thickness = self.handle_rtss(
@@ -152,8 +153,8 @@ class MovingImageLoader(ImageLoader):
             # handle DVH calculation
             if 'rtdose' in file_names_dict and self.calc_dvh:
                 if manual:
-                    progress_callback.emit(("Calculating DVHs...", 40))
-                else:
+                    progress_callback(("Calculating DVHs...", 40))
+                elif hasattr(progress_callback, "emit"):
                     progress_callback.emit(("Calculating DVHs...", 60))
                 ok = self.handle_dvh(dataset_rtss, rois, dict_thickness,
                                      file_names_dict, moving_dict_container,
@@ -164,22 +165,25 @@ class MovingImageLoader(ImageLoader):
         else:
             # no RTSS present, create temporary RTSS
             if manual:
-                progress_callback.emit(("Generating temporary rtss...", 40))
-            else:
+                progress_callback(("Generating temporary rtss...", 40))
+            elif hasattr(progress_callback, "emit"):
                 progress_callback.emit(("Generating temporary rtss...", 20))
-            
+
             ok = self.create_model_and_rtss(path)
             if not ok or interrupt_flag.is_set():
                 return False
 
         # Show moving model loading
         if manual:
-            progress_callback.emit(("Loading Moving Model", 45))
-        else:
+            progress_callback(("Loading Moving Model", 45))
+        elif hasattr(progress_callback, "emit"):
             progress_callback.emit(("Loading Moving Model", 85))
-        
-        if interrupt_flag.is_set():
+
+        if interrupt_flag.is_set() and manual:
+            progress_callback(("Stopping", 85))
+        elif hasattr(progress_callback, "emit"):
             progress_callback.emit(("Stopping", 85))
+
             return False
 
         return True
@@ -188,3 +192,4 @@ class MovingImageLoader(ImageLoader):
     def load_manual_mode(self, interrupt_flag, progress_callback):
         # We will just use the same loading functions as above but with different progress updates
         return self.load(interrupt_flag, progress_callback, manual=True)
+    


### PR DESCRIPTION
Fixed the not loading with mac, used python threading
Fixed auto fusion not loading

## Summary by Sourcery

Add threaded loading and progress queue to Image Fusion UI to fix macOS loading issues and improve error handling

New Features:
- Introduce a progress queue polled by ImageFusionProgressWindow via QTimer
- Enable manual fusion loading in a background Python thread with interrupt flag and progress queue

Bug Fixes:
- Fix manual fusion loading hang on macOS by moving loader into a separate thread with proper progress reporting
- Fix auto fusion branch not loading by handling boolean result types and showing error dialogs
- Replace commonprefix with commonpath in MovingImageLoader to correctly compute shared directory

Enhancements:
- Unify progress_callback usage in ManualFusionLoader and MovingImageLoader as direct callback calls
- Add robust exception handling in MovingImageLoader.load with helper method to emit progress and errors
- Connect fusion mode radio buttons to revalidate and toggle the Confirm button upon mode changes